### PR TITLE
chore: Remove cat wrangler.toml command from CI/CD workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -64,8 +64,6 @@ jobs:
         EOF
       env:
         UNIQUE_HASH: ${{ env.UNIQUE_HASH }}
-    - name: cat wrangler.toml
-      run: cat wrangler.toml
     - name: Publish to Cloudflare Workers (Staging)
       run: wrangler deploy --env stg-${{ env.UNIQUE_HASH }}
       env:


### PR DESCRIPTION
The cat wrangler.toml command is no longer needed in the CI/CD workflow. This commit removes the command to improve the efficiency of the workflow.

Signed-off-by: Victor Palade <victor@cloudflavor.io>