### PR TITLE
chore: Update routes in CI/CD workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -55,9 +55,8 @@ jobs:
         [env.stg-${{ env.UNIQUE_HASH }}]
         zone_name = "cloudflavor.io"
         routes = [
-          # temporarilly disabled till cloudflare certs are back
-          # { pattern = "oscar.stg.cloudflavor.io/${{ env.UNIQUE_HASH }}/*", zone_name = "cloudflavor.io"}, 
-          # { pattern = "oscar.stg.cloudflavor.io", zone_name = "cloudflavor.io", custom_domain = true },
+          { pattern = "oscar.stg.cloudflavor.io/${{ env.UNIQUE_HASH }}/*", zone_name = "cloudflavor.io"}, 
+          { pattern = "oscar.stg.cloudflavor.io", zone_name = "cloudflavor.io", custom_domain = true },
         ]
         rate_limit = { threshold = 500, period = 60 }
         vars = { OSCAR_LOG_LEVEL = "debug" }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,7 +8,7 @@ workers_dev = false
 
 [env.prd]
 routes = [
-    # { pattern = "oscar.cloudflavor.io", zone_name = "cloudflavor.io", custom_domain = true },
+    { pattern = "oscar.cloudflavor.io", zone_name = "cloudflavor.io", custom_domain = true },
 ]
 
 [env.prd.vars]


### PR DESCRIPTION
This commit updates the routes in the CI/CD workflow to enable the "oscar.stg.cloudflavor.io" pattern and custom domain for the staging environment. The previous routes were temporarily disabled, but now they are re-enabled. This change improves the functionality of the workflow.