### PR TITLE
chore: Update routes in CI/CD workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -53,11 +53,6 @@ jobs:
       run: |
         cat <<EOF >> wrangler.toml
         [env.stg-${{ env.UNIQUE_HASH }}]
-        zone_name = "cloudflavor.io"
-        routes = [
-          { pattern = "oscar.stg.cloudflavor.io/${{ env.UNIQUE_HASH }}/*", zone_name = "cloudflavor.io"}, 
-          { pattern = "oscar.stg.cloudflavor.io", zone_name = "cloudflavor.io", custom_domain = true },
-        ]
         rate_limit = { threshold = 500, period = 60 }
         vars = { OSCAR_LOG_LEVEL = "debug" }
         EOF

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,8 +3,6 @@ name = "oscar"
 main = "src/index.ts"
 compatibility_date = "2024-06-05"
 compatibility_flags = ["nodejs_compat"]
-workers_dev = false
-
 
 [env.prd]
 routes = [


### PR DESCRIPTION
This is done because the let's encrypt cert authority keeps rate limiting the deployments. It seems that the TLS certs are regenerated with each deployment.

Signed-off-by: Victor Palade <victor@cloudflavor.io>