### PR TITLE
feat: Add command registry for handling GitHub commands

### DIFF
--- a/src/commands/github.ts
+++ b/src/commands/github.ts
@@ -31,6 +31,7 @@ function newCommandRegistry(): CommandRegistry {
     commandRegistry.registerCommand('/restart-action', handleRestartActionCommand);
     commandRegistry.registerCommand('/reviewers', handleReviewersCommand);
     commandRegistry.registerCommand('/assign', handleAssigneesCommand);
+    commandRegistry.registerCommand('/triage', handleTriageCommand);
 
     return commandRegistry;
 }
@@ -45,7 +46,7 @@ async function handleLabelCommand(command: string, app: Octokit, payload: any): 
             owner: payload.repository.owner.login,
             repo: payload.repository.name,
             issue_number: payload.issue.number,
-            labels: labels
+            labels
         });
 
         console.log(`Added labels "${labels.join(', ')}" to issue #${payload.issue.number}`);
@@ -58,6 +59,17 @@ async function handleLabelCommand(command: string, app: Octokit, payload: any): 
         console.log('cleared all labels');
     }
 }
+async function handleTriageCommand(command: string, app: Octokit, payload: any): Promise<void> {
+    await app.rest.issues.removeLabel({
+        owner: payload.repository.owner.login,
+        repo: payload.repository.name,
+        issue_number: payload.issue.number,
+        name: 'needs-triage',
+    });
+
+    console.log(`Added "needs-triage" label to issue #${payload.issue.number}`);
+}
+
 
 async function handleRestartActionCommand(command: string, app: Octokit, payload: any): Promise<void> {
     const actionId = command.slice('/restart-action'.length).trim();

--- a/src/commands/github.ts
+++ b/src/commands/github.ts
@@ -1,0 +1,105 @@
+import { Octokit } from 'octokit';
+
+class CommandRegistry {
+    private handlers: { [key: string]: (command: string, app: Octokit, payload: any) => Promise<void>; } = {};
+
+    registerCommand(
+        commandPrefix: string,
+        handler: (command: string, app: Octokit, payload: any)
+            => Promise<void>) {
+        this.handlers[commandPrefix] = handler;
+    }
+
+    async processCommand(command: string, app: Octokit, payload: any): Promise<boolean> {
+        const commandPrefix =
+            Object.keys(this.handlers).find(prefix => command.startsWith(prefix));
+
+        if (commandPrefix) {
+            await this.handlers[commandPrefix](command, app, payload);
+            return true;
+        } else {
+            console.log(`No handler found for command: ${command}`);
+            return false;
+        }
+    }
+}
+
+function newCommandRegistry(): CommandRegistry {
+    const commandRegistry = new CommandRegistry();
+
+    commandRegistry.registerCommand('/label', handleLabelCommand);
+    commandRegistry.registerCommand('/restart-action', handleRestartActionCommand);
+    commandRegistry.registerCommand('/reviewers', handleReviewersCommand);
+    commandRegistry.registerCommand('/assign', handleAssigneesCommand);
+
+    return commandRegistry;
+}
+
+async function handleLabelCommand(command: string, app: Octokit, payload: any): Promise<void> {
+    const match = command.match(/^\/label(?:\s+(.*))?$/);
+    const labelsStr = match ? (match[1] || '').trim() : '';
+    const labels = labelsStr ? labelsStr.split(' ').map(label => label.trim()) : [];
+
+    if (labels.length > 0) {
+        await app.rest.issues.addLabels({
+            owner: payload.repository.owner.login,
+            repo: payload.repository.name,
+            issue_number: payload.issue.number,
+            labels: labels
+        });
+
+        console.log(`Added labels "${labels.join(', ')}" to issue #${payload.issue.number}`);
+    } else {
+        await app.rest.issues.removeAllLabels({
+            owner: payload.repository.owner.login,
+            repo: payload.repository.name,
+            issue_number: payload.issue.number
+        });
+        console.log('cleared all labels');
+    }
+}
+
+async function handleRestartActionCommand(command: string, app: Octokit, payload: any): Promise<void> {
+    const actionId = command.slice('/restart-action'.length).trim();
+
+    if (actionId) {
+        // Logic to restart the action with the given ID
+        console.log(`Restarting action with ID "${actionId}"`);
+        // Insert your logic to restart the action here
+    } else {
+        console.log(`No action ID specified in the command: ${command}`);
+    }
+}
+
+async function handleAssigneesCommand(command: string, app: Octokit, payload: any) {
+    const match = command.match(/^\/assign(?:\s+(.*))?$/);
+    const assigneesStr = match ? match[1].trim() : '';
+    const assignees = assigneesStr ? assigneesStr.split(' ').map(assignee => assignee.trim().replace(/^@/, '')) : [];
+
+    await app.rest.issues.addAssignees({
+        owner: payload.repository.owner.login,
+        repo: payload.repository.name,
+        issue_number: payload.issue.number,
+        assignees,
+    });
+
+    console.log(`Assigning issue #${payload.issue.number} to ${assignees.join(', ')}`);
+}
+
+async function handleReviewersCommand(command: string, app: Octokit, payload: any): Promise<void> {
+    const match = command.match(/^\/reviewers(?:\s+(.*))?$/);
+    const reviewersStr = match ? match[1].trim() : '';
+    const reviewers = reviewersStr ? reviewersStr.split(' ').map(reviewer => reviewer.trim().replace(/^@/, '')) : [];
+    console.log(reviewers);
+
+    await app.rest.pulls.requestReviewers({
+        owner: payload.repository.owner.login,
+        repo: payload.repository.name,
+        pull_number: payload.issue.number,
+        reviewers,
+    });
+
+    console.log(`Request review for pull request #${payload.issue.number} from ${reviewers.join(', ')}`);
+}
+
+export { newCommandRegistry };

--- a/src/common.ts
+++ b/src/common.ts
@@ -10,3 +10,7 @@ export type Env = {
 };
 
 export type Handler = RouterHandler<Env, ExecutionContext, Request>;
+
+export const sleep = (ms: number) => {
+    return new Promise(resolve => setTimeout(resolve, ms));
+};

--- a/src/github/githubEvents.ts
+++ b/src/github/githubEvents.ts
@@ -43,29 +43,26 @@ export default async (env: Env, installationId: number): Promise<App> => {
 
     app.webhooks.on('issue_comment', async ({ payload }) => {
         try {
-            if (payload.comment.body.startsWith('/')) {
-                console.log('Processing command:', payload.comment.body);
-                const resp =
-                    await commandRegistry.processCommand(
-                        payload.comment.body,
-                        authApp,
-                        payload,
-                    );
+            const resp =
+                await commandRegistry.processCommand(
+                    payload.comment.body,
+                    authApp,
+                    payload,
+                );
 
-                console.log('Command processed:', resp);
+            console.log('Command processed:', resp);
 
-                if (!resp) {
-                    await authApp.rest.issues.createComment({
-                        owner: payload.repository.owner.login,
-                        repo: payload.repository.name,
-                        issue_number: payload.issue.number,
-                        body: "Can't say I understand that command. 🤔",
-                    });
-                }
+            if (!resp) {
+                await authApp.rest.issues.createComment({
+                    owner: payload.repository.owner.login,
+                    repo: payload.repository.name,
+                    issue_number: payload.issue.number,
+                    body: "Can't say I understand that command. 🤔",
+                });
             }
 
         } catch (error: any) {
-            console.error('Error while adding labels:', error.message);
+            console.error('Error while processing command on issue_comment:', error.message);
         }
     });
 

--- a/src/github/githubEvents.ts
+++ b/src/github/githubEvents.ts
@@ -1,6 +1,8 @@
 import { App, Octokit } from 'octokit';
 
 import { Env } from '../common';
+import { newCommandRegistry } from '../commands/github';
+
 
 export default async (env: Env, installationId: number): Promise<App> => {
     const app = new App({
@@ -21,7 +23,9 @@ export default async (env: Env, installationId: number): Promise<App> => {
         console.error('Error while authenticating:', error.message);
     }
 
-    app.webhooks.on('issues.opened', async ({ id, name, payload }) => {
+    const commandRegistry = newCommandRegistry();
+
+    app.webhooks.on('issues.opened', async ({ payload }) => {
         try {
             await addLabels(authApp, payload.repository.owner.login, payload.repository.name, payload.issue.number, ['needs-triage']);
         } catch (error: any) {
@@ -29,7 +33,7 @@ export default async (env: Env, installationId: number): Promise<App> => {
         }
     });
 
-    app.webhooks.on('pull_request.opened', async ({ id, name, payload }) => {
+    app.webhooks.on('pull_request.opened', async ({ payload }) => {
         try {
             await addLabels(authApp, payload.repository.owner.login, payload.repository.name, payload.pull_request.number, ['needs-triage']);
         } catch (error: any) {
@@ -37,8 +41,36 @@ export default async (env: Env, installationId: number): Promise<App> => {
         }
     });
 
+    app.webhooks.on('issue_comment', async ({ payload }) => {
+        try {
+            if (payload.comment.body.startsWith('/')) {
+                console.log('Processing command:', payload.comment.body);
+                const resp =
+                    await commandRegistry.processCommand(
+                        payload.comment.body,
+                        authApp,
+                        payload,
+                    );
+
+                console.log('Command processed:', resp);
+
+                if (!resp) {
+                    await authApp.rest.issues.createComment({
+                        owner: payload.repository.owner.login,
+                        repo: payload.repository.name,
+                        issue_number: payload.issue.number,
+                        body: "Can't say I understand that command. 🤔",
+                    });
+                }
+            }
+
+        } catch (error: any) {
+            console.error('Error while adding labels:', error.message);
+        }
+    });
+
     return app;
-}
+};
 
 async function checkIfLabelsExist(authApp: Octokit, owner: string, repo: string, labels: string[]): Promise<void> {
     const existingLabels = await authApp.rest.issues.listLabelsForRepo({


### PR DESCRIPTION
The code changes introduce a new `github.ts` file that contains a `CommandRegistry` class and several command handler functions. The `CommandRegistry` class allows registering command handlers based on command prefixes. The `processCommand` method processes incoming commands and executes the corresponding handler. This addition enables the handling of commands like `/label`, `/restart-action`, `/reviewers`, and `/assign`. The new functionality improves the ability to interact with GitHub repositories through commands.