### PR TITLE
commands: introduce new commands

### DIFF
--- a/src/github/githubEvents.ts
+++ b/src/github/githubEvents.ts
@@ -36,12 +36,22 @@ export default async (env: Env, installationId: number): Promise<App> => {
     app.webhooks.on('pull_request.opened', async ({ payload }) => {
         try {
             await addLabels(authApp, payload.repository.owner.login, payload.repository.name, payload.pull_request.number, ['needs-triage']);
+            authApp.rest.reactions.createForIssueComment({
+                owner: payload.repository.owner.login,
+                repo: payload.repository.name,
+                comment_id: payload.pull_request.id,
+                content: '+1',
+            });
         } catch (error: any) {
             console.error('Error while adding labels:', error.message);
         }
     });
 
     app.webhooks.on('issue_comment', async ({ payload }) => {
+        if (!payload.comment.body.startsWith('/')) {
+            return;
+        }
+
         try {
             const resp =
                 await commandRegistry.processCommand(
@@ -49,8 +59,6 @@ export default async (env: Env, installationId: number): Promise<App> => {
                     authApp,
                     payload,
                 );
-
-            console.log('Command processed:', resp);
 
             if (!resp) {
                 await authApp.rest.issues.createComment({
@@ -66,8 +74,34 @@ export default async (env: Env, installationId: number): Promise<App> => {
         }
     });
 
+    app.webhooks.on('workflow_run', async ({ payload }) => {
+        const repo = authApp.rest.repos.get({
+            owner: payload.repository.owner.login,
+            repo: payload.repository.name,
+        });
+
+        if (payload.workflow_run.conclusion === 'failure' && payload.workflow_run.head_branch === 'main') {
+            // TODO: need to just update the issues instead of creating a new one every
+            // time.
+            // Otherwise it will create an issue for all of the failed runs.
+            try {
+                const resp = await authApp.rest.issues.create({
+                    owner: payload.repository.owner.login,
+                    repo: payload.repository.name,
+                    title: 'Workflow failed',
+                    body: `The main branch workflow failed. Please check the logs and fix the issue. ${payload.workflow_run.html_url}`,
+                });
+                await addLabels(authApp, payload.repository.owner.login, payload.repository.name, resp.data.number, ['ci-failure']);
+            } catch (error: any) {
+                console.error('Error while creating issue:', error.message);
+            }
+        }
+    });
+
+
     return app;
 };
+
 
 async function checkIfLabelsExist(authApp: Octokit, owner: string, repo: string, labels: string[]): Promise<void> {
     const existingLabels = await authApp.rest.issues.listLabelsForRepo({

--- a/src/github/httpHandler.ts
+++ b/src/github/httpHandler.ts
@@ -26,5 +26,5 @@ const githubHandler: Handler =
         }
 
         return new Response('OK', { status: 200 });
-    }
+    };
 export { githubHandler };


### PR DESCRIPTION
These changes introduce restart-workflow, stop-workflow, cancel-workflow
close, reopen, merge, rename.
It also adds a new event for workflow_run failed. If a failed job is detected for the main event, then a new issue is created by the bot that references it.
This new issue will be labeled with failed-ci for now.

Signed-off-by: Victor Palade <victor@cloudflavor.io>