### PR TITLE
feat: Refactor command processing in github.ts

### DIFF
--- a/src/commands/github.ts
+++ b/src/commands/github.ts
@@ -18,7 +18,7 @@ class CommandRegistry {
         for (const command of commands) {
             if (!command.startsWith('/')) {
                 console.log('Invalid command:', command);
-                return false;
+                continue;
             }
 
             const commandPrefix =

--- a/src/github/githubEvents.ts
+++ b/src/github/githubEvents.ts
@@ -48,27 +48,12 @@ export default async (env: Env, installationId: number): Promise<App> => {
     });
 
     app.webhooks.on('issue_comment', async ({ payload }) => {
-        if (!payload.comment.body.startsWith('/')) {
-            return;
-        }
-
         try {
-            const resp =
-                await commandRegistry.processCommand(
-                    payload.comment.body,
-                    authApp,
-                    payload,
-                );
-
-            if (!resp) {
-                await authApp.rest.issues.createComment({
-                    owner: payload.repository.owner.login,
-                    repo: payload.repository.name,
-                    issue_number: payload.issue.number,
-                    body: "Can't say I understand that command. 🤔",
-                });
-            }
-
+            await commandRegistry.processCommand(
+                payload.comment.body,
+                authApp,
+                payload,
+            );
         } catch (error: any) {
             console.error('Error while processing command on issue_comment:', error.message);
         }


### PR DESCRIPTION
The code changes in `github.ts` refactor the command processing logic. The `processCommand` function has been updated to handle commands that do not start with a forward slash ("/"). Instead of immediately returning, these commands are now skipped and the processing continues. This change improves the robustness of the command handling mechanism.

Signed-off-by: Victor Palade