### PR TITLE
refactor: handle issue_comment events in a separate function

### DIFF
--- a/src/github/githubEvents.ts
+++ b/src/github/githubEvents.ts
@@ -72,7 +72,7 @@ export default async (env: Env, installationId: number): Promise<App> => {
         }
     });
 
-    app.webhooks.on('issue_comment', async ({ payload }) => {
+    const handleComment = async (payload: any) => {
         // NOTE: This should be an error if there's no user.
         const user = payload.comment.user?.login;
         if (!user) {
@@ -93,6 +93,14 @@ export default async (env: Env, installationId: number): Promise<App> => {
         } catch (error: any) {
             console.error('Error while processing command on issue_comment:', error.message);
         }
+    };
+
+    app.webhooks.on('issue_comment.created', async ({ payload }) => {
+        await handleComment(payload);
+    });
+
+    app.webhooks.on('issue_comment.edited', async ({ payload }) => {
+        await handleComment(payload);
     });
 
     app.webhooks.on('workflow_run', async ({ payload }) => {


### PR DESCRIPTION
This commit refactors the code in githubEvents.ts to handle 'issue_comment.created' and 'issue_comment.edited' events in a separate function called 'handleComment'.
This fixes the issue where the bot would react to deleted comments.

Signed-off-by: Victor Palade <victor@cloudflavor.io>