### PR TITLE
feat: Add more commands.

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -25,6 +25,9 @@ export type Config = {
     checkPermissions(user: string): boolean;
 };
 
+// NOTE: can't find this union type in the codebase for octokit
+export type ReactionContent = '+1' | '-1' | 'laugh' | 'confused' | 'heart' | 'hooray' | 'rocket' | 'eyes';
+
 const parseTomlConfig =
     async (uri: string): Promise<Config | undefined> => {
         const response = await fetch(uri);

--- a/src/github/githubEvents.ts
+++ b/src/github/githubEvents.ts
@@ -1,6 +1,6 @@
 import { App, Octokit } from 'octokit';
 
-import { Config, Env, parseTomlConfig } from '../common';
+import { Config, Env, parseTomlConfig, ReactionContent } from '../common';
 import { newCommandRegistry } from '../commands/github';
 
 
@@ -47,6 +47,14 @@ export default async (env: Env, installationId: number): Promise<App> => {
                 payload.issue.number,
                 ['needs-triage'],
             );
+
+
+            await authApp.rest.reactions.createForIssue({
+                owner: payload.repository.owner.login,
+                repo: payload.repository.name,
+                issue_number: payload.issue.number,
+                content: 'eyes',
+            });
         } catch (error: any) {
             console.error('Error while adding labels:', error.message);
         }
@@ -61,12 +69,17 @@ export default async (env: Env, installationId: number): Promise<App> => {
                 payload.pull_request.number,
                 ['needs-triage']
             );
-            authApp.rest.reactions.createForIssueComment({
-                owner: payload.repository.owner.login,
-                repo: payload.repository.name,
-                comment_id: payload.pull_request.id,
-                content: '+1',
-            });
+
+            const reactions: ReactionContent[] = ['+1', 'rocket', 'heart'];
+
+            for (const content of reactions) {
+                await authApp.rest.reactions.createForIssueComment({
+                    owner: payload.repository.owner.login,
+                    repo: payload.repository.name,
+                    comment_id: payload.pull_request.id,
+                    content,
+                });
+            }
         } catch (error: any) {
             console.error('Error while adding labels:', error.message);
         }


### PR DESCRIPTION
lock/unlock - lock, unlock an issue.
milestone - add a milestone. mileston clear will remove it.
pin/unpin - pin/unpin issue. had to use graphql since rest does not seem to provide a way to update the issue for pinning.

draft - move a PR to draft. this only works on payed plans.
approve/unapprove - does what it says on the thin. It also adds more clauses to merge command, like not merging if it's already merged, if it's a draft, if it has conflicts, etc.

Signed-off-by: Victor Palade <victor@cloudflavor.io>